### PR TITLE
Require the redirector gem

### DIFF
--- a/lib/spree_redirector.rb
+++ b/lib/spree_redirector.rb
@@ -1,2 +1,3 @@
+require 'redirector'
 require 'spree_core'
 require 'spree_redirector/engine'


### PR DESCRIPTION
Fixes a bug where if not required would throw an error `uninitialized
constant RedirectRule` if the gem wasn't explicitly included in the
Gemfile.
